### PR TITLE
JobShopSchedule Class - Simplified Code

### DIFF
--- a/Director.m
+++ b/Director.m
@@ -19,13 +19,13 @@ classdef Director < handle
             SchEndNode=2;
 
             %source node - node 1 is the start of the schedule
-            source=[1 3];
+            source=[1 3 4];
             %target node - node 3 is the finish node
-            target=[3 2];
+            target=[3 4 2];
             %weights - ***duration of the activity***
-            weight=[2 2];
+            weight=[2 2 2];
             %Activity (Edge) Name
-            operation={'A'; 'B'};
+            operation={'A'; 'B'; 'C'};
             
             %creation of the digraph object which contains the routing for
             %the WO

--- a/JobShopSchedule.m
+++ b/JobShopSchedule.m
@@ -19,6 +19,9 @@ classdef JobShopSchedule < handle
         %add WOs to Job Shop master schedule
         function [master_schedule revised_wo_dates]=addWoToMasterSchedule(obj,wos_add_master)
             
+            %initialize master_schedule
+            master_schedule=obj.master_schedule;
+            
             %create revised_wo_dates structure
             revised_wo_dates=struct('id',[],'start_date',[],'end_date',[]);
             
@@ -26,145 +29,180 @@ classdef JobShopSchedule < handle
             if ~isempty(wos_add_master)
                 
                 if isempty(obj.master_schedule.Nodes) %check to see if the js_sch object has any data in it
-                    %find the earliest start date
+                    %organize work orders by due date
+                    %assuption is this is the FIFO shop prioritized by due date
                     [temp index]=sort([wos_add_master.start_date]);
-                    %loop through wos_add_master and add WO routing to the master schedule
                     
+                    %*** Serialize Work Orders ***
                     for i=1:length(wos_add_master)
-                        %no need to check due date for the first WO
-                        %extract the wo unique id
-                        u_id=wos_add_master(index(i)).unique_id;
-                        %extract the wo routing
-                        tempG=wos_add_master(index(i)).routing;
-                        %extrace the wo critical path duration
-                        cp_duration=wos_add_master(index(i)).cp_duration;
                         
+                        %assume the first work order starts at t=0
+                        %populate a structure with revised information
+                        %assuming all work order are performed serially
                         if i==1
                             %assume the first work order starts at t=0
                             %populate a structure with revised information
-                            revised_wo_dates.id(i)=u_id;
+                            revised_wo_dates.id(i)=wos_add_master(index(i)).unique_id;
                             revised_wo_dates.start_date(i)=0;
-                            revised_wo_dates.end_date(i)=revised_wo_dates.start_date(i)+cp_duration;
+                            revised_wo_dates.end_date(i)=revised_wo_dates.start_date(i)+wos_add_master(index(i)).cp_duration;
+                        else
+                            revised_wo_dates.id(i)=wos_add_master(index(i)).unique_id;
+                            revised_wo_dates.start_date(i)=revised_wo_dates.end_date(i-1);
+                            revised_wo_dates.end_date(i)=revised_wo_dates.start_date(i)+wos_add_master(index(i)).cp_duration;
+                        end
+                    end
+                    %*** End Work Order Serialization***
+                    
+                    %*** Add Operations to Empty Master Schedule***
+                    for i=1:length(wos_add_master)
+                        %extract information to temp variable to make it
+                        %easier to work with - note index is from the sort
+                        %command based on due date above which enforces
+                        %FIFO based on customer supplied due date
+                        
+                        %wo unique id
+                        u_id=wos_add_master(index(i)).unique_id;
+                        %wo routing
+                        tempG=wos_add_master(index(i)).routing;                    
+                        
+                        %to simplify the creation of the master schedule, each routing start and end will
+                        %have a start lead and an end lag, the weighting
+                        %will be calculated from the revised serial dates
+                        
+                        for j=1:length(tempG.Edges.EndNodes)
+                            %for all routing node 1 is start and node 2 is
+                            %end
+                            rout_source=tempG.Edges.EndNodes(j,1);
+                            rout_target=tempG.Edges.EndNodes(j,2);
                             
-                            %loop through the WO routing edges and add them to the master schedule digraph
-                            for j=1:length(tempG.Edges.EndNodes)
+                            if rout_source==1 && rout_target~=2 %edge is the first routing operation
+                                %add in start lead edge
+                                source=obj.start_node;
+                                target={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,1))]};
+                                weight=revised_wo_dates.start_date(i);
+                                master_schedule=addedge(master_schedule,source,target,weight);
+                                %find new edge index
+                                edge_index=findedge(master_schedule,source,target);
+                                %adding edge labels to the master schedule Edges table
+                                master_schedule.Edges.EdgeLabel{edge_index}=['Start.Lead.',num2str(u_id),'=',num2str(weight)];
+                                %adding additional routing information to the Edges table
+                                master_schedule.Edges.EdgeWO(edge_index)=u_id;
+                                master_schedule.Edges.OperationWO{edge_index}=['StartLead'];
+                                master_schedule.Edges.RoutingEndNodes(edge_index,:)=[NaN tempG.Edges.EndNodes(j,1)];
                                 
-                                if j==1 %first loop thru the WO routing
-                                    source=obj.start_node;
-                                    %target node is named unique wo id dot edge ending node - the edges of are more importance
-                                    target={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,2))]};
-                                    weight=tempG.Edges.Weight(j);
-                                    master_schedule=addedge(obj.master_schedule,source,target,weight);
-                                    %adding edge labels to the master schedule
-                                    %naming convention: WO id dot Operation = Operation Duration
-                                    edge_label{j,1}=[num2str(u_id),'.',char(tempG.Edges.Operation(j)),'=',num2str(weight)];
-                                    %adding additional routing information
-                                    %ot the Edges table for future
-                                    %use/reference
-                                    edge_wo(j,1)=u_id;
-                                    operation_wo{j,1}=char(tempG.Edges.Operation(j));
-                                    routing_end_nodes(j,:)=tempG.Edges.EndNodes(j,:);
-                                    
-                                    master_schedule.Edges.EdgeLabel=edge_label; %gives the edges a label name that is WO_id.Operation=Duration
-                                    master_schedule.Edges.EdgeWO=edge_wo; %add the WO unique ID to each edge in the edges table
-                                    master_schedule.Edges.OperationWO=operation_wo; %add the WO operation identifier to each edge in the edges table 
-                                    master_schedule.Edges.RoutingEndNodes=routing_end_nodes; %add the WO routing end nodes for each edge in the edges table
-                                    
-                                else %all other loops thru the very first WO routing in the master schedule
-                                    source={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,1))]};
-                                    target={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,2))]};
-                                    weight=tempG.Edges.Weight(j);
-                                    master_schedule=addedge(master_schedule,source,target,weight);
-                                    edge_label{j,1}=[num2str(u_id),'.',char(tempG.Edges.Operation(j)),'=',num2str(weight)];                                 
-                                    edge_wo(j,1)=u_id;
-                                    operation_wo{j,1}=char(tempG.Edges.Operation(j));
-                                    routing_end_nodes(j,:)=tempG.Edges.EndNodes(j,:);
-                                    
-                                    master_schedule.Edges.EdgeLabel=edge_label; %gives the edges a label name that is WO_id.Operation=Duration
-                                    master_schedule.Edges.EdgeWO=edge_wo; %add the WO unique ID to each edge in the edges table
-                                    master_schedule.Edges.OperationWO=operation_wo; %add the WO operation identifier to each edge in the edges table 
-                                    master_schedule.Edges.RoutingEndNodes=routing_end_nodes; %add the WO routing end nodes for each edge in the edges table
-                                    
-                                    
-                                end
-                            end
-                            
-                        else %all other loops thru second to nth WO
-                            %adjust the start date of the next work order
-                            %to right after the previous one
-                            
-                            %populate a structure with revised information
-                            revised_wo_dates.id(i)=u_id;
-                            revised_wo_dates.start_date(i)=revised_wo_dates.end_date(i-1)+1;
-                            revised_wo_dates.end_date(i)=revised_wo_dates.start_date(i)+cp_duration;
-                            
-                            %??? indexing for master schedule will need to be based on a counter ???
-                            ct=length(master_schedule.Edges.EndNodes)+1;
-                            
-                            %extract the wo unique id
-                            u_id=wos_add_master(index(i)).unique_id;
-                            %extract the wo routing
-                            tempG=wos_add_master(index(i)).routing;
-                            %extrace the wo critical path duration
-                            cp_duration=wos_add_master(index(i)).cp_duration;
-                            
-                            for j=1:length(tempG.Edges.EndNodes)+1
+                                %add the first operation to the schedule
+                                source={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,1))]};
+                                target={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,2))]};
+                                weight=tempG.Edges.Weight(j);
+                                master_schedule=addedge(master_schedule,source,target,weight);
+                                %find new edge index
+                                edge_index=findedge(master_schedule,source,target);
+                                %adding edge labels to the master schedule Edges table
+                                master_schedule.Edges.EdgeLabel{edge_index}=[num2str(u_id),'.',char(tempG.Edges.Operation(j)),'=',num2str(weight)];
+                                %adding additional routing information to the Edges table
+                                master_schedule.Edges.EdgeWO(edge_index)=u_id;
+                                master_schedule.Edges.OperationWO{edge_index}=char(tempG.Edges.Operation(j));
+                                master_schedule.Edges.RoutingEndNodes(edge_index,:)=[tempG.Edges.EndNodes(j,1) tempG.Edges.EndNodes(j,2)];
+                            elseif rout_source~=1 && rout_target==2 %edge is the last routing operation
+                                %add the last operation to the schedule
+                                source={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,1))]};
+                                target={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,2))]};
+                                weight=tempG.Edges.Weight(j);
+                                master_schedule=addedge(master_schedule,source,target,weight);
+                                %find new edge index
+                                edge_index=findedge(master_schedule,source,target);
+                                %adding edge labels to the master schedule Edges table
+                                master_schedule.Edges.EdgeLabel{edge_index}=[num2str(u_id),'.',char(tempG.Edges.Operation(j)),'=',num2str(weight)];
+                                %adding additional routing information to the Edges table
+                                master_schedule.Edges.EdgeWO(edge_index)=u_id;
+                                master_schedule.Edges.OperationWO{edge_index}=char(tempG.Edges.Operation(j));
+                                master_schedule.Edges.RoutingEndNodes(edge_index,:)=[tempG.Edges.EndNodes(j,1) tempG.Edges.EndNodes(j,2)];
                                 
-                                if j==1 %first loop thru the WO routing
-                                    source=obj.start_node;
-                                    %since these WOs occur serially, there
-                                    %is a lead time between the start of
-                                    %the simulation and the start of the
-                                    %next work order called
-                                    %Start.Lead.wo_id.node
-                                    target={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,1))]};
-                                    weight=revised_wo_dates.start_date(i)-revised_wo_dates.start_date(i-1);
-                                    master_schedule=addedge(master_schedule,source,target,weight);
-                                    
-                                    %find edge index
-                                    edge_index=findedge(master_schedule,source,target);
-                                    %adding edge labels to the master schedule
-                                    %naming convention: WO id dot Operation = Operation Duration
-                                    master_schedule.Edges.EdgeLabel{edge_index}=['Start.Lead.',num2str(u_id),'=',num2str(weight)];
-                                    %adding additional routing information
-                                    %ot the Edges table for future
-                                    %use/reference
-                                    master_schedule.Edges.EdgeWO(edge_index)=u_id;
-                                    master_schedule.Edges.OperationWO{edge_index}=char(tempG.Edges.Operation(j));
-                                    master_schedule.Edges.RoutingEndNodes(edge_index,:)=[NaN tempG.Edges.EndNodes(j,1)];
-                                    
-                                else %all other loops thru the very first WO routing in the master schedule
-                                    %??? need to go to j-1 index ???
-%                                     source={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,1))]};
-%                                     target={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,2))]};
-%                                     weight=tempG.Edges.Weight(j);
-%                                     master_schedule=addedge(master_schedule,source,target,weight);
-%                                     edge_label{j,1}=[num2str(u_id),'.',char(tempG.Edges.Operation(j)),'=',num2str(weight)];                                 
-%                                     edge_wo(j,1)=u_id;
-%                                     operation_wo{j,1}=char(tempG.Edges.Operation(j));
-%                                     routing_end_nodes(j,:)=tempG.Edges.EndNodes(j,:);
-%                                     
-%                                     master_schedule.Edges.EdgeLabel=edge_label; %gives the edges a label name that is WO_id.Operation=Duration
-%                                     master_schedule.Edges.EdgeWO=edge_wo; %add the WO unique ID to each edge in the edges table
-%                                     master_schedule.Edges.OperationWO=operation_wo; %add the WO operation identifier to each edge in the edges table 
-%                                     master_schedule.Edges.RoutingEndNodes=routing_end_nodes; %add the WO routing end nodes for each edge in the edges table
-                                    
-                                    
-                                end
-                                %increment the counter
-                                ct=ct+1;
+                                %add the end lag edge to the schedule
+                                source={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,2))]};
+                                target=obj.end_node;
+                                weight=0;
+                                master_schedule=addedge(master_schedule,source,target,weight);
+                                %find new edge index
+                                edge_index=findedge(master_schedule,source,target);
+                                %adding edge labels to the master schedule Edges table
+                                master_schedule.Edges.EdgeLabel{edge_index}=['End.Lag.',num2str(u_id)];
+                                %adding additional routing information to the Edges table
+                                master_schedule.Edges.EdgeWO(edge_index)=u_id;
+                                master_schedule.Edges.OperationWO{edge_index}='EndLag';
+                                master_schedule.Edges.RoutingEndNodes(edge_index,:)=[tempG.Edges.EndNodes(j,2) NaN];
+                            elseif rout_source==1 && rout_target==2 %single operation in the routing
+                                %add in start lead edge
+                                source=obj.start_node;
+                                target={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,1))]};
+                                weight=revised_wo_dates.start_date(i);
+                                master_schedule=addedge(master_schedule,source,target,weight);
+                                %find new edge index
+                                edge_index=findedge(master_schedule,source,target);
+                                %adding edge labels to the master schedule Edges table
+                                master_schedule.Edges.EdgeLabel{edge_index}=['Start.Lead.',num2str(u_id),'=',num2str(weight)];
+                                %adding additional routing information to the Edges table
+                                master_schedule.Edges.EdgeWO(edge_index)=u_id;
+                                master_schedule.Edges.OperationWO{edge_index}=['StartLead'];
+                                master_schedule.Edges.RoutingEndNodes(edge_index,:)=[NaN tempG.Edges.EndNodes(j,1)];
+                                
+                                %add the only operation to the schedule
+                                source={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,1))]};
+                                target={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,2))]};
+                                weight=tempG.Edges.Weight(j);
+                                master_schedule=addedge(master_schedule,source,target,weight);
+                                %find new edge index
+                                edge_index=findedge(master_schedule,source,target);
+                                %adding edge labels to the master schedule Edges table
+                                master_schedule.Edges.EdgeLabel{edge_index}=[num2str(u_id),'.',char(tempG.Edges.Operation(j)),'=',num2str(weight)];
+                                %adding additional routing information to the Edges table
+                                master_schedule.Edges.EdgeWO(edge_index)=u_id;
+                                master_schedule.Edges.OperationWO{edge_index}=char(tempG.Edges.Operation(j));
+                                master_schedule.Edges.RoutingEndNodes(edge_index,:)=[tempG.Edges.EndNodes(j,1) tempG.Edges.EndNodes(j,2)];
+                                
+                                %add the end lag edge to the schedule
+                                source={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,2))]};
+                                target=obj.end_node;
+                                weight=0;
+                                master_schedule=addedge(master_schedule,source,target,weight);
+                                %find new edge index
+                                edge_index=findedge(master_schedule,source,target);
+                                %adding edge labels to the master schedule Edges table
+                                master_schedule.Edges.EdgeLabel{edge_index}=['End.Lag.',num2str(u_id)];
+                                %adding additional routing information to the Edges table
+                                master_schedule.Edges.EdgeWO(edge_index)=u_id;
+                                master_schedule.Edges.OperationWO{edge_index}='EndLag';
+                                master_schedule.Edges.RoutingEndNodes(edge_index,:)=[tempG.Edges.EndNodes(j,2) NaN];
+                            else %fo all other operations in the WO
+                                %add the operation to the schedule
+                                source={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,1))]};
+                                target={[num2str(u_id),'.',num2str(tempG.Edges.EndNodes(j,2))]};
+                                weight=tempG.Edges.Weight(j);
+                                master_schedule=addedge(master_schedule,source,target,weight);
+                                %find new edge index
+                                edge_index=findedge(master_schedule,source,target);
+                                %adding edge labels to the master schedule Edges table
+                                master_schedule.Edges.EdgeLabel{edge_index}=[num2str(u_id),'.',char(tempG.Edges.Operation(j)),'=',num2str(weight)];
+                                %adding additional routing information to the Edges table
+                                master_schedule.Edges.EdgeWO(edge_index)=u_id;
+                                master_schedule.Edges.OperationWO{edge_index}=char(tempG.Edges.Operation(j));
+                                master_schedule.Edges.RoutingEndNodes(edge_index,:)=[tempG.Edges.EndNodes(j,1) tempG.Edges.EndNodes(j,2)];
                             end
                             
                         end
-                     
                     end
+                    %*** End Add Operations to Empty Master Schedule***
+                    
                 else %if the master schedule already has data in it then
-                    %if not then append WOs to master schedule
-                    %assumptions: JS works on FIFO, all serial operations,no parallel functionally simialar machines
+                    %calcuate the critical path through the master sch
+                    %sort the new WOs based on due date
+                    %calculate revised dates using critical path
+                    %add new WOs to master
                 end
+                %perform fwd/bwd schedule passes - calc early/late start/finish
+                %pass info to update WO due dates
             end
-        %??? need to update WO due dates ???
-    end
+        end
     end
 end
 


### PR DESCRIPTION
By adding lead and lag edges for all WOs to the master schedule graph significantly simplified the code. More lines, but faster to write.

To pretty this up, a lot of the operations occurring in the code could be written as static functions in the class... future goals!!!